### PR TITLE
feat: init bitwarden-secrets-sdk at 0.3.0

### DIFF
--- a/nixos/_common/users/aaron/default.nix
+++ b/nixos/_common/users/aaron/default.nix
@@ -23,6 +23,7 @@ in
 
     initialPassword = "hunter2";
     packages = with pkgs; [
+      bitwarden-secrets-sdk
       chezmoi
       git
       home-manager

--- a/packages/bitwarden-secrets-sdk/default.nix
+++ b/packages/bitwarden-secrets-sdk/default.nix
@@ -1,0 +1,34 @@
+{ pkgs
+, ...
+}:
+let
+  pname = "bitwarden-secrets-manager-sdk";
+  version = "0.3.0";
+in
+
+with pkgs;
+
+rustPlatform.buildRustPackage {
+  inherit pname;
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "bitwarden";
+    repo = "sdk";
+    rev = "bws-v${version}";
+    hash = "sha256-o+tmO9E881futhA/fN6+EX2yEBKnKUmKk/KilIt5vYY=";
+  };
+
+  buildInputs = [ openssl ];
+
+  nativeBuildInputs = [ pkg-config python310 ];
+
+  cargoSha256 = "sha256-bCV9i87IhqB6jxtnkgYpvluoT8YOjKwx8viajrB5u18=";
+
+  meta = {
+    changelog = "https://github.com/bitwarden/sdk/releases/tag/${src.rev}";
+    description = "Bitwarden Secrets Manager SDK";
+    homepage = "https://bitwarden.com";
+    mainProgram = "bws";
+  };
+}

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -1,6 +1,7 @@
 # Custom packages, that can be defined similarly to ones from nixpkgs
 # You can build them using 'nix build .#example' or (legacy) 'nix-build -A example'
 { pkgs ? (import ../nixpkgs.nix) { }, ... }: {
+  bitwarden-secrets-sdk = pkgs.callPackage ./bitwarden-secrets-sdk { };
   nix-inspect = pkgs.callPackage ./nix-inspect { };
 }
 


### PR DESCRIPTION
## Description of changes

Adds a new package to work with bitwarden-secrets-manager

## Things done

- Built on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`
- [x] Tested, as applicable.
- [x] Fits [CONTRIBUTING.md](https://github.com/aaron-dodd/nix-config/blob/main/CONTRIBUTING.md).
