### PR TITLE
feat: add flake support for development shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -114,6 +114,12 @@
       # These are usually stuff you would upstream into home-manager
       homeManagerModules = import ./modules/home-manager;
 
+      # Devshell for bootstrapping, acessible via 'nix develop' or 'nix-shell' (legacy)
+      devShells = forAllSystems (system:
+        let pkgs = nixpkgs.legacyPackages.${system};
+        in import ./shell.nix { inherit pkgs; }
+      );
+
       # NixOS configuration entrypoint
       # Available through 'nixos-rebuild --flake .#your-hostname'
       nixosConfigurations = {

--- a/shell.nix
+++ b/shell.nix
@@ -4,7 +4,12 @@
   default = pkgs.mkShell {
     # Enable experimental features without having to specify the argument
     NIX_CONFIG = "experimental-features = nix-command flakes repl-flake";
-    nativeBuildInputs = with pkgs; [ nix home-manager git ];
+    nativeBuildInputs = with pkgs; [
+      git
+      home-manager
+      nix
+      sops
+    ];
   };
 }
 


### PR DESCRIPTION
## Description of changes

Adds default development shell support for our flake configuration

## Things done

- Built on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`
- [x] Tested, as applicable.
- [x] Fits [CONTRIBUTING.md](https://github.com/aaron-dodd/nix-config/blob/main/CONTRIBUTING.md).
