### PR TITLE
feat: implement initial amnesiac module

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -41,6 +41,21 @@
         "type": "github"
       }
     },
+    "impermanence": {
+      "locked": {
+        "lastModified": 1694622745,
+        "narHash": "sha256-z397+eDhKx9c2qNafL1xv75lC0Q4nOaFlhaU1TINqb8=",
+        "owner": "nix-community",
+        "repo": "impermanence",
+        "rev": "e9643d08d0d193a2e074a19d4d90c67a874d932e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "impermanence",
+        "type": "github"
+      }
+    },
     "nix-formatter-pack": {
       "inputs": {
         "nixpkgs": [
@@ -146,6 +161,7 @@
       "inputs": {
         "disko": "disko",
         "home-manager": "home-manager",
+        "impermanence": "impermanence",
         "nix-formatter-pack": "nix-formatter-pack",
         "nixpkgs": "nixpkgs",
         "nixpkgs-master": "nixpkgs-master",

--- a/flake.nix
+++ b/flake.nix
@@ -20,6 +20,11 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
+    # Disk erasure
+    impermanence = {
+      url = "github:nix-community/impermanence";
+    };
+
     # Home directory configuration
     home-manager = {
       url = "github:nix-community/home-manager/release-23.05";

--- a/modules/nixos/amnesia/default.nix
+++ b/modules/nixos/amnesia/default.nix
@@ -1,0 +1,93 @@
+{ config, lib, inputs, ... }:
+with lib;
+let
+  cfg = config.nixos.amnesia;
+in
+{
+  imports = [
+    inputs.impermanence.nixosModules.impermanence
+  ];
+
+  options.nixos.amnesia = {
+    enable = mkOption {
+      type = types.bool;
+      description = "Whether to enable the amnesiac configuration.";
+      default = false;
+    };
+    baseDirectory = mkOption {
+      type = types.path;
+      description = "The base directory to store persistent state.";
+      default = "/persist";
+    };
+    users = mkOption {
+      type = types.listOf types.str;
+      description = "Users to map password files for.";
+      default = [ "aaron" ];
+    };
+  };
+
+  config = mkIf cfg.enable (mkMerge [
+    {
+      fileSystems.${cfg.baseDirectory}.neededForBoot = true;
+
+      # cfg.baseDirectory is the location you plan to store the files
+      environment.persistence.${cfg.baseDirectory} = {
+        # Hide these mount from the sidebar of file managers
+        hideMounts = true;
+
+        # Folders you want to map
+        directories = [
+          "/etc/NetworkManager/system-connections"
+          "/var/lib/containers"
+          "/var/lib/tailscale"
+          "/var/log"
+        ];
+
+        files = [
+          "/etc/data.keyfile"
+          "/etc/machine-id"
+        ];
+      };
+
+      # Persisting user passwords
+      users.mutableUsers = mkForce false;
+      users.users = mkMerge ([{ root.passwordFile = "${cfg.baseDirectory}/passwords/root"; }] ++
+        forEach cfg.users (user:
+          {
+            "${user}" = {
+              initialPassword = mkForce null;
+              passwordFile = "${cfg.baseDirectory}/passwords/${user}";
+            };
+          }
+        )
+      );
+    }
+    (mkIf config.services.openssh.enable {
+      # cfg.baseDirectory is the location you plan to store the files
+      environment.persistence.${cfg.baseDirectory} = {
+        files = [
+          "/etc/ssh/ssh_host_ed25519_key.pub"
+          "/etc/ssh/ssh_host_ed25519_key"
+          "/etc/ssh/ssh_host_rsa_key.pub"
+          "/etc/ssh/ssh_host_rsa_key"
+        ];
+      };
+
+      services.openssh.hostKeys = mkForce [
+        {
+          path = "${toString cfg.baseDirectory}/etc/ssh/ssh_host_ed25519_key";
+          type = "ed25519";
+        }
+        {
+          path = "${toString cfg.baseDirectory}/etc/ssh/ssh_host_rsa_key";
+          type = "rsa";
+          bits = 4096;
+        }
+      ];
+    })
+    (mkIf config.nixos.oci-containers.enable {
+      nixos.oci-containers.volumeBaseDir = "${cfg.baseDirectory}/container-volumes";
+    })
+  ]);
+}
+

--- a/modules/nixos/default.nix
+++ b/modules/nixos/default.nix
@@ -3,6 +3,7 @@
 {
   # List your module files here
   # my-module = import ./my-module.nix;
+  amnesia = import ./amnesia;
   oci-containers = import ./oci-containers;
 }
 

--- a/nixos/_common/services/amnesia.nix
+++ b/nixos/_common/services/amnesia.nix
@@ -1,0 +1,5 @@
+{
+  nixos.amnesia.enable = true;
+  nixos.amnesia.baseDirectory = "/persist";
+}
+

--- a/nixos/vmware/configuration.nix
+++ b/nixos/vmware/configuration.nix
@@ -14,6 +14,7 @@ in
 
     ../_common/global
     ../_common/desktop/gnome.nix
+    ../_common/services/amnesia.nix
     ../_common/services/flatpak.nix
     ../_common/services/localisation.nix
     ../_common/services/mosh.nix

--- a/nixos/vmware/disks.nix
+++ b/nixos/vmware/disks.nix
@@ -40,6 +40,14 @@
                     mountOptions = [ "compress=zstd" "noatime" ];
                     mountpoint = "/nix";
                   };
+                  "/persist" = {
+                    mountOptions = [ "compress=zstd" ];
+                    mountpoint = "/persist";
+                  };
+                  "/tmp" = {
+                    mountOptions = [ "compress=zstd" "noatime" ];
+                    mountpoint = "/tmp";
+                  };
                 };
               };
             };

--- a/nixos/vmware/disks.nix
+++ b/nixos/vmware/disks.nix
@@ -2,7 +2,7 @@
 {
   disko.devices = {
     disk = {
-      sda = {
+      main = {
         type = "disk";
         device = builtins.elemAt disks 0;
         content = {
@@ -28,8 +28,16 @@
               content = {
                 type = "btrfs";
                 extraArgs = [ "-f" ]; # Override existing partition
+                postCreateHook = ''
+                  MNTPOINT=$(mktemp -d)
+                  trap 'umount $MNTPOINT/root; umount $MNTPOINT; rm -rf $MNTPOINT' EXIT
+
+                  mount /dev/disk/by-partlabel/disk-main-root $MNTPOINT -o subvol=/
+                  mount /dev/disk/by-partlabel/disk-main-root $MNTPOINT/root -o subvol=/root
+                  btrfs subvolume snapshot -r "$MNTPOINT/root" "$MNTPOINT/root-blank"
+                '';
                 subvolumes = {
-                  "/rootfs" = {
+                  "/root" = {
                     mountpoint = "/";
                   };
                   "/home" = {

--- a/scripts/btrfs-diff.sh
+++ b/scripts/btrfs-diff.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# btrfs-diff.sh
+set -euo pipefail
+
+MNTPOINT=$(mktemp -d)
+sudo mkdir --parents "$MNTPOINT"
+sudo mount -o subvol=/ "/dev/disk/by-partlabel/disk-main-root" "$MNTPOINT"
+
+OLD_TRANSID=$(sudo btrfs subvolume find-new "$MNTPOINT/root-blank" 9999999)
+OLD_TRANSID=${OLD_TRANSID#transid marker was }
+
+sudo btrfs subvolume find-new "$MNTPOINT/root" "$OLD_TRANSID" |
+sed '$d' | cut -f17- -d' ' | sort | uniq |
+while read -r path; do
+  path="/$path"
+  if [ -L "$path" ]; then
+    : # The path is a symbolic link, so is probably handled by NixOS already
+  elif [ -d "$path" ]; then
+    : # The path is a directory, ignore
+  else
+    echo "$path"
+  fi
+done
+
+sudo umount "$MNTPOINT"
+sudo rm -rf "$MNTPOINT"
+


### PR DESCRIPTION
## Description of changes

Add an amnesiac / stateless management module

## Things done

- Built on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`
- [x] Tested, as applicable.
- [x] Fits [CONTRIBUTING.md](https://github.com/aaron-dodd/nix-config/blob/main/CONTRIBUTING.md).
