### PR TITLE
feat: add app documentation for non-nixos systems

### DIFF
--- a/docs/APPS.md
+++ b/docs/APPS.md
@@ -1,0 +1,27 @@
+# Applications I Use
+
+The following in a non-exhaustive list of software which I use across
+different devices.
+
+## SmartPhone
+
+My smartphone OS of choice is Android. Most of these apps are available on the
+Google Play store or on the F-Droid store.
+
+ - Aegis Authenticator
+ - AnkiDroid
+ - F-Droid App Store
+ - Firefox
+ - KeePassDX
+ - ProtonMail Calendar
+ - ProtonMail E-Mail
+ - Signal
+ - Simon Tatham's Puzzle Collection
+ - Simple Mobile Tools (https://www.simplemobiletools.com)
+ - Syncthing
+ - Tachiyomi
+ - Tailscale
+ - Termux
+
+The remaining apps I use are various banking, messengers and misc apps.
+


### PR DESCRIPTION
## Description of changes

Adds documentation describing non-nixos apps

## Things done

- Built on platform(s)
  - [ ] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`
- [ ] Tested, as applicable.
- [ ] Fits [CONTRIBUTING.md](https://github.com/aaron-dodd/nix-config/blob/main/CONTRIBUTING.md).
