### PR TITLE
feat: init tailscale client and server

### DIFF
--- a/modules/nixos/amnesia/default.nix
+++ b/modules/nixos/amnesia/default.nix
@@ -69,7 +69,6 @@ in
         # Folders you want to map
         directories = [
           "/etc/NetworkManager/system-connections"
-          "/var/lib/tailscale"
           "/var/log"
         ];
 
@@ -141,6 +140,13 @@ in
     (mkIf config.services.flatpak.enable {
       environment.persistence.${cfg.baseDirectory}.directories = [
         "/var/lib/flatpak"
+      ];
+    })
+
+    # Tailscale
+    (mkIf config.services.tailscale.enable {
+      environment.persistence.${cfg.baseDirectory}.directories = [
+        "/var/lib/tailscale"
       ];
     })
 

--- a/nixos/_common/services/tailscale-exit-node.nix
+++ b/nixos/_common/services/tailscale-exit-node.nix
@@ -1,0 +1,10 @@
+{
+  imports = [
+    ./tailscale
+  ];
+
+  services.tailscale = {
+    useRoutingFeatures = "both";
+  };
+}
+

--- a/nixos/_common/services/tailscale.nix
+++ b/nixos/_common/services/tailscale.nix
@@ -1,0 +1,16 @@
+{ config, lib, ... }: {
+  services.tailscale = {
+    enable = true;
+    useRoutingFeatures = lib.mkDefault "client";
+  };
+
+  networking.firewall = {
+    checkReversePath = "loose";
+
+    # Facilitate firewall punching
+    allowedUDPPorts = [
+      config.services.tailscale.port
+    ];
+  };
+}
+

--- a/nixos/vmware/configuration.nix
+++ b/nixos/vmware/configuration.nix
@@ -22,6 +22,7 @@ in
     ../_common/services/oci-containers.nix
     ../_common/services/pipewire.nix
     ../_common/services/printing.nix
+    ../_common/services/tailscale.nix
     ../_common/users/aaron
   ];
 


### PR DESCRIPTION
## Description of changes

Adds host services for tailscale client / server

## Things done

- Built on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`
- [x] Tested, as applicable.
- [x] Fits [CONTRIBUTING.md](https://github.com/aaron-dodd/nix-config/blob/main/CONTRIBUTING.md).
