### PR TITLE
fix: remove dependabot.yml blank line

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,11 @@
 version: 2
 updates:
-- package-ecosystem: "github-actions"
-  directory: "/"
-  schedule:
-    interval: "daily"
-    time: "04:00"
-  open-pull-requests-limit: 10
-  reviewers:
-  - aaron-dodd
-  assignees:
-  - aaron-dodd
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    reviewers:
+      - aaron-dodd
+    assignees:
+      - aaron-dodd


### PR DESCRIPTION
## Description of changes

**Include a brief description of the changes**

## Things done

- Built on platform(s)
  - [ ] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`
- [ ] Tested, as applicable.
- [ ] Fits [CONTRIBUTING.md](https://github.com/aaron-dodd/nix-config/blob/main/CONTRIBUTING.md).
